### PR TITLE
Use field labels in the CSV header

### DIFF
--- a/exporters/csv.ini
+++ b/exporters/csv.ini
@@ -5,5 +5,17 @@ label = csv
 
 [use]
 plugin = basics
+plugin = lodex
+
+[env]
+path = from
+value = env('fields').map('name')
+
+path = to
+value = env('fields').map('label')
+
+[keyMapping]
+from = env('from')
+to = env('to')
 
 [CSVString]

--- a/exporters/csv.spec.js
+++ b/exporters/csv.spec.js
@@ -117,3 +117,39 @@ test('export in CSV resources containing semicolon', done => {
         })
         .on('error', done);
 });
+
+test('export CSV with labels in header', done => {
+    let outputString = '';
+    from([
+        {
+            uri: 'http://resource.uri/1',
+            AbCd: 'first;resource',
+        },
+        {
+            uri: 'http://resource.uri/2',
+            AbCd: 'second resource',
+        },
+    ])
+        .pipe(
+            ezs(
+                'delegate',
+                { file: __dirname + '/csv.ini' },
+                { fields: [{ name: 'AbCd', label: 'Title' }] },
+            ),
+        )
+        .on('data', data => {
+            if (data) outputString += data;
+        })
+        .on('end', () => {
+            const res = outputString.split('\r\n');
+            expect(res).toHaveLength(4);
+            expect(res).toEqual([
+                'uri;Title',
+                'http://resource.uri/1;"first;resource"',
+                'http://resource.uri/2;second resource',
+                '',
+            ]);
+            done();
+        })
+        .on('error', done);
+});

--- a/exporters/extended-nquads.spec.js
+++ b/exporters/extended-nquads.spec.js
@@ -79,7 +79,7 @@ test('export single resource with more documents', done => {
         })
         .on('end', () => {
             const res = outputString.split('\n');
-            expect(res).toHaveLength(9);
+            expect(res).toHaveLength(10);
             expect(res[0]).toEqual('<https://api.istex.fr/ark:/67375/8QZ-ZD0W8F1F-N> <http://uri/language> <http://uri/cat> .');
             expect(res[1]).toEqual('<https://api.istex.fr/ark:/67375/8QZ-D0VV05V0-2> <http://uri/language> <http://uri/cat> .');
             expect(res[2]).toEqual('<https://api.istex.fr/ark:/67375/8QZ-G1FHMTKW-9> <http://uri/language> <http://uri/cat> .');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ezs": "9.3.0",
     "ezs-basics": "3.8.1",
     "ezs-istex": "6.1.0",
-    "ezs-lodex": "5.0.0",
+    "ezs-lodex": "5.3.0",
     "from": "0.1.7",
     "jest": "24.8.0"
   },


### PR DESCRIPTION
During the integration of csv exporter into LODEX (see [Trello](https://trello.com/c/uKCumeUW/183-int%C3%A9grer-lexporter-csv-%C3%A0-lodex)) I saw that its was exactly the same as the previous one.
The columns names are not the fields' _labels_, but their _name_ (4-letters identifier).

It has to be fixed (because it breaks ready-model paradigm).

In order to do that, one has to write a new ezs statement, which maps objects keys.
E.g. `keyMapping` that, for an object `{ dFgH: "value" }` and a mapping parameter `{ dFgH: "Title" }` would give the object `{ Title: "value"  }` (for all keys).

Once that statement created, one could give a `mapping` parameter this way (for the LODEX `fields` case):

```
[env]
path = mapping
value = env('fields').map(function(field) { var res = {}; res[field.name] = field.label; return res; })
```

Because `fields` contains: `[{ name: "AbCd", label: "Title" }, { ... }]`.