### PR TITLE
feat: add sub-resources-co-occurrences-with-uri routines

### DIFF
--- a/public/routines/sub-resources-co-occurrences-with-uri.ini
+++ b/public/routines/sub-resources-co-occurrences-with-uri.ini
@@ -1,0 +1,119 @@
+; Export with only some value (id, title, summary, etc.)
+; This routine do the same thing as sub-resources-co-occurrences be is getting the third parameter via the uri give by the format
+; Example call:
+;   - /api/run/sub-resources-co-occurrences-with-uri/aHOZ/dqff ('aHOZ' being the field identifier of the main resource,
+;                                                      'dqff' is the field containing the name of the element to compare)
+;
+
+prepend = delegate?file=../worker.ini
+mimeType = application/json
+label = Get all element in relation with the current one
+
+[use]
+plugin = basics
+plugin = lodex
+plugin = analytics
+
+[buildContext]
+connectionStringURI = get('connectionStringURI')
+
+; Keep some env variable
+[env?singleton]
+path = minValue
+value = env('minValue').parseInt().defaultTo(0)
+
+path = maxValue
+value = env('maxValue').parseInt().defaultTo(1000000)
+
+path = maxSize
+value = env('maxSize').parseInt().defaultTo(10)
+
+path = reverse
+value = env('orderBy').split('/').get(1).replace('asc', 0).replace('desc', 1).parseInt()
+
+path = tuneBy
+value = env('orderBy').split('/').get(0).replace('_id', 'id')
+
+path = fields
+value = get('fields')
+
+path = host
+value = get('host')
+
+; Get the necessary parameter for the first query
+[assign]
+path = matchField
+value = env('field.0')
+
+path = joinField
+value = env('field.1')
+
+path = matchUri
+value = env('uri')
+
+; Give the connectionStringURI to the second Query
+path = referer.connectionStringURI
+value = get('connectionStringURI')
+
+; Ask for subresource and not resource
+path = filter.subresourceId
+value = fix({ '$exists': true })
+
+; Get the matchValue (three parameter)
+[LodexAggregateQuery]
+stage = fix([ `$project: { _id: 1, matchValue: '$versions.${self.joinField}' }`, `$unwind: '$matchValue'` ])
+
+[assign]
+path = connectionStringURI
+value = get('referer.connectionStringURI')
+
+; Get filtered data
+; matchField => env('field.0') => aHOZ (see call example)
+; joinField => env('field.1') => dqff (see call example)
+; matchValue come from the previous query and is available in the stream
+[LodexJoinQuery]
+matchField = env('field.0')
+joinField = env('field.1')
+
+[filterVersions]
+[filterContributions]
+
+; find the fields which are selected for title and summary
+[assign]
+path = titleFieldName
+value = env('field.1')
+
+path = host
+value = env('host')
+
+[assign]
+path = id
+value = get('uri')
+
+path = title
+value = get(self.titleFieldName).toString()
+
+path = date_published
+value = get('publicationDate')
+
+path = url
+value = pick(['host', 'uri']).values().join('/')
+
+; Send only a part of the data
+[slice]
+start = 1
+size = env('maxSize')
+
+; Keep only the necessary data
+[keep]
+path = id
+path = url
+path = title
+path = summary
+path = date_published
+path = total
+
+[LodexOutput]
+keyName = items
+indent = true
+extract = total

--- a/public/routines/sub-resources-co-occurrences.ini
+++ b/public/routines/sub-resources-co-occurrences.ini
@@ -41,9 +41,9 @@ path = host
 value = get('host')
 
 ; Get filtered data
-; env('field.0') => aHOZ
-; env('field.1') => dqff
-; env('field.2') => Mus musculus
+; matchField => env('field.0') => aHOZ (see call example)
+; joinField => env('field.1') => dqff (see call example)
+; matchValue => env('field.2') => Mus musculus (see call example)
 [LodexJoinQuery]
 matchField = env('field.0')
 matchValue = env('field.2')


### PR DESCRIPTION
Do the same thing as `sub-resources-co-occurrences` but it use uri instead of the third parameter

