### PR TITLE
fix(json-conditor): fixes the identify bug and two fields

### DIFF
--- a/public/loaders/json-conditor.ini
+++ b/public/loaders/json-conditor.ini
@@ -132,7 +132,7 @@ scheme = sha
 
 [assign]
 path = uri
-value =get('uri').replace('sha:/', 'uri:/')
+value = get('uri').replace('sha:/', 'uri:/')
 
 [exchange]
 value = omit(['ws'])

--- a/public/loaders/json-conditor.ini
+++ b/public/loaders/json-conditor.ini
@@ -62,14 +62,14 @@ value = get("host.conference.name")
 path = host/conference/place
 value = get("host.conference.place")
 
-path = keywords/en/authors
-value = get("keywords.en.authors")
+path = keywords/en/author
+value = get("keywords.en.author")
 
 path = keywords/en/mesh
 value = get("keywords.en.mesh")
 
-path = keywords/fr/authors
-value = get("keywords.fr.authors")
+path = keywords/fr/author
+value = get("keywords.fr.author")
 
 path = keywords/fr/mesh
 value = get("keywords.fr.mesh")
@@ -123,6 +123,13 @@ value = get("host.volume").concat(_.get(self,"host.issue")).concat(_.get(self,"h
 
 path = ApilProvenance
 value = get("sourceUids").castArray().map(s => s.split("$")[0]).uniq()
+
+[identify]
+scheme = sha
+
+[assign]
+path = uri
+value =get('uri').replace('sha:/', 'uri:/')
 
 [exchange]
 value = omit(['ws'])


### PR DESCRIPTION
Modification du loader `json-conditor.ini` pour gérer la ligne `scheme = sha` et corriger les champs mots clés d'auteur FR et EN